### PR TITLE
Ability to pass additional arguments to pg_tmp.sh

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -5,6 +5,6 @@ interface ConnectionOptions {
   database: string;
 }
 
-function pgTmp(setEnvironment?: boolean): Promise<ConnectionOptions>
+function pgTmp(setEnvironment?: boolean, opts?: string[]): Promise<ConnectionOptions>
 
 export = pgTmp

--- a/index.js
+++ b/index.js
@@ -4,10 +4,10 @@ const url = require('url')
 
 const bin = path.join(__dirname, 'pg_tmp.sh')
 
-module.exports = function pgTmp (setEnvironment) {
+module.exports = function pgTmp (setEnvironment, opts = []) {
   setEnvironment = (setEnvironment == null ? true : setEnvironment)
 
-  return execa.stdout(bin).then((connection) => {
+  return execa.stdout(bin, opts).then((connection) => {
     const parsed = url.parse(connection, true)
 
     const result = {

--- a/readme.md
+++ b/readme.md
@@ -32,9 +32,13 @@ describe('My app', () => {
 
 ## API
 
-### `createDatabase([setEnvironment]) => Promise`
+### `createDatabase([setEnvironment], [opts]) => Promise`
 
 Start a temporary database that will be cleaned up automatically after being used. If `setEnvironment` is either not provided, or set to true, the standard [postgresql environmental variables](https://www.postgresql.org/docs/9.1/static/libpq-envars.html) will be set so that you can connect directly without any additional config.
+
+`opts` is an array of arguments that can be passed to pg_tmp.sh (`usage: pg_tmp [-w timeout] [-t] [-o extra-options] [-d datadir]`).
+
+For example `createDatabase(true, ['-t', '-w', '180'])`.
 
 Returns a `Promise` of a object with the following properties:
 

--- a/test.js
+++ b/test.js
@@ -42,6 +42,15 @@ describe('pg-tmp', function () {
     })
   })
 
+  it('should accept and pass additional parameters', () => {
+    return createDatabase(true, ['-t', '-w', '180']).then((result) => {
+      assert.strictEqual(result.host, undefined, 'host should be set')
+      assert.notStrictEqual(result.user, undefined, 'user should be set')
+      assert.strictEqual(result.password, '', 'password should be set')
+      assert.notStrictEqual(result.database, undefined, 'database should be set')
+    })
+  })
+
   it('should allow connections to the database', () => {
     return createDatabase().then(() => {
       const client = new pg.Client()


### PR DESCRIPTION
This PR enables using additional arguments to `pg_tmp.sh` script, when initializing the database from Node.JS code.